### PR TITLE
Move DATABASE_PATH into processs.env

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "scripts": {
     "dev": "vike dev",
     "build": "vike build",
-    "preview": "vike build && NODE_ENV=production node dist/server/index.js",
+    "preview": "vike build && NODE_ENV=production DATABASE_PATH='./database.sqlite' node dist/server/index.js",
     "proto": "pbjs -t static-module -w es6 --es6 -o repo/proto/bundle.js repo/proto/sentence.proto repo/proto/ruleset.proto && pbts -o repo/proto/bundle.d.ts repo/proto/bundle.js",
     "lint:check": "eslint .",
     "lint": "eslint --fix .",

--- a/repo/database.ts
+++ b/repo/database.ts
@@ -17,7 +17,7 @@
 import fs from 'node:fs'
 import sqlite3 from 'sqlite3'
 
-export const db = new sqlite3.Database(import.meta.env.DATABASE_PATH)
+export const db = new sqlite3.Database(process.env.DATABASE_PATH ?? '')
 
 export const initDB = () => {
   return new Promise<void>((resolve, reject) => {

--- a/server/vite.d.ts
+++ b/server/vite.d.ts
@@ -16,10 +16,6 @@
 
 /// <reference types="vite/client" />
 
-interface ImportMetaEnv {
-  readonly DATABASE_PATH: string
-}
-
 interface ImportMeta {
   readonly env: ImportMetaEnv
 }

--- a/vite.d.ts
+++ b/vite.d.ts
@@ -16,10 +16,6 @@
 
 /// <reference types="vite/client" />
 
-interface ImportMetaEnv {
-  readonly DATABASE_PATH: string
-}
-
 interface ImportMeta {
   readonly env: ImportMetaEnv
 }


### PR DESCRIPTION
This PR moves the `DATABASE_PATH` into the `process.env`. Using `import.meta.env` hard-codes the values at build-time, not at run-time.