### PR TITLE
Fix Font Links

### DIFF
--- a/pages/+Head.tsx
+++ b/pages/+Head.tsx
@@ -24,11 +24,11 @@ export const Head = () => {
         crossOrigin='anonymous'
       />
       <link
-        href='https://fonts.googleapis.com/css2?family=Noto+Sans+Mono:wght@100..900&family=Noto+Sans:ital,wght@0,100..900;1,100..900&display=swap'
+        href='https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,100..900;1,100..900&display=swap'
         rel='stylesheet'
       />
       <link
-        href='https://fonts.googleapis.com/css2?family=Noto+Sans+Mono:wght@100..900&family=Noto+Sans:ital,wght@0,100..900;1,100..900&display=swap'
+        href='https://fonts.googleapis.com/css2?family=Noto+Sans+Mono:wght@100..900&display=swap'
         rel='stylesheet'
       />
       {import.meta.env.PROD && (


### PR DESCRIPTION
This PR fixes the duplicate font links by breaking them into two. It appears that Cloudflare Fonts does not support multiple fonts on the same link tag.