### PR TITLE
Added Redirects for Missing Routes

### DIFF
--- a/pages/+config.ts
+++ b/pages/+config.ts
@@ -22,5 +22,10 @@ import image from '../images/tree.jpeg'
 export const config = {
   favicon,
   image,
+  redirects: {
+    '/sentence': '/',
+    '/viewer': '/',
+    '/rules*': '/'
+  },
   extends: vikeReact
 } satisfies Config


### PR DESCRIPTION
This PR adds missing redirects for `/sentence`, `/viewer`, and `/rules/*` routes.