### PR TITLE
fix(docker): base container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:24-trixie-slim AS base
+FROM node:24-trixie AS base
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"


### PR DESCRIPTION
This PR changes the base image to `node:24-trixie`, which include the necessary build tools to build this application.